### PR TITLE
Fix dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import os
+import sys
 from setuptools import setup, find_packages
+try:
+    import PyQt4
+except ImportError:
+    print('PyQt4 not found. Please install it first. If using a virtualenv, you '
+          'may need to install vext.pyqt4', file=sys.stderr)
+    sys.exit(1)
 
 __version__ = "1.3.5"
 
@@ -29,6 +37,6 @@ setup(
     author = "Oleg Smirnov",
     author_email = "osmirnov@gmail.com",
     url = "https://github.com/ska-sa/tigger",
-    requires=['astro_kittens', 'PyQt4', 'numpy', 'astlib'],
+    install_requires=['astro_kittens', 'numpy', 'scipy', 'astlib', 'pyfits<3.4']
 )
 


### PR DESCRIPTION
There are a number of fixes here:
- It's given the correct name (`install_requires`) so that it will
  actually have an effect on the package manager.
- PyQt4 is removed from install_requires, since it is not a
  PyPA-installable package. Instead, a check is added to fail setup if
  it is not already installed.
- Added missing scipy and pyfits dependencies. pyfits depends on <3.4
  due to #71; once that is fixed (e.g. via #73) it should be changed,
  probably to >=3.1.