### PR TITLE
Fix version on last py2 supported lsm reader

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 from __future__ import print_function
 from setuptools import setup, find_packages
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 
-requirements = ['numpy', 'scipy', 'astlib', 'astropy', 'astro_tigger_lsm', 'configparser']
+requirements = ['numpy', 'scipy', 'astlib', 'astropy', 'astro_tigger_lsm <= 1.6.0', 'configparser']
 
 scripts = [
     'TigGUI/tigger',


### PR DESCRIPTION
This is a kludge until @razman786's changes have been tested and incorporated. lsm reader has now left the py2 space.