### PR TITLE
Fixes Issue 121

### DIFF
--- a/TigGUI/Images/Controller.py
+++ b/TigGUI/Images/Controller.py
@@ -393,7 +393,7 @@ class ImageController(QFrame):
 
     def colourctrl_dockwidget_closed(self):
         self._dockable_colour_ctrl.setVisible(False)
-        self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() - self._dockable_colour_ctrl.width())
+        self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
 
     def colourctrl_dockwidget_toggled(self):
         if self._dockable_colour_ctrl.isVisible():

--- a/TigGUI/Images/Controller.py
+++ b/TigGUI/Images/Controller.py
@@ -352,7 +352,9 @@ class ImageController(QFrame):
         else:
             self._control_dialog.hide()
             self._dockable_colour_ctrl.setVisible(False)
-            self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
+            if self.parent().mainwin.windowState() != Qt.WindowMaximized:
+                self.parent().mainwin.setMaximumWidth(
+                    self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
 
     def addDockWidgetToTab(self):
         # Add dockable widget to main window.
@@ -393,7 +395,8 @@ class ImageController(QFrame):
 
     def colourctrl_dockwidget_closed(self):
         self._dockable_colour_ctrl.setVisible(False)
-        self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
+        if self.parent().mainwin.windowState() != Qt.WindowMaximized:
+            self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
 
     def colourctrl_dockwidget_toggled(self):
         if self._dockable_colour_ctrl.isVisible():
@@ -401,7 +404,9 @@ class ImageController(QFrame):
                 self._dockable_colour_ctrl.setFloating(False)
             else:
                 self._dockable_colour_ctrl.setFloating(True)
-                self.parent().mainwin.setMaximumWidth(self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
+                if self.parent().mainwin.windowState() != Qt.WindowMaximized:
+                    self.parent().mainwin.setMaximumWidth(
+                        self.parent().mainwin.width() + self._dockable_colour_ctrl.width())
 
     def _changeDisplayRangeToPercent(self, percent):
         if not self._control_dialog:

--- a/TigGUI/Plot/SkyModelPlot.py
+++ b/TigGUI/Plot/SkyModelPlot.py
@@ -1212,7 +1212,8 @@ class SkyModelPlotter(QWidget):
         for ea_action in list_of_actions:
             if ea_action.text() == 'Show live zoom && cross-sections':
                 self._dockable_livezoom.setVisible(False)
-                self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_livezoom.width())
+                if self._mainwin.windowState() != Qt.WindowMaximized:
+                    self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_livezoom.width())
                 ea_action.setChecked(False)
 
     def liveprofile_dockwidget_closed(self):
@@ -1220,7 +1221,8 @@ class SkyModelPlotter(QWidget):
         for ea_action in list_of_actions:
             if ea_action.text() == 'Show profiles':
                 self._dockable_liveprofile.setVisible(False)
-                self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_liveprofile.width())
+                if self._mainwin.windowState() != Qt.WindowMaximized:
+                    self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_liveprofile.width())
                 ea_action.setChecked(False)
 
     def liveprofile_dockwidget_toggled(self):
@@ -1229,7 +1231,8 @@ class SkyModelPlotter(QWidget):
                 self._dockable_liveprofile.setFloating(False)
             else:
                 self._dockable_liveprofile.setFloating(True)
-                self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_liveprofile.width())
+                if self._mainwin.windowState() != Qt.WindowMaximized:
+                    self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_liveprofile.width())
 
     def livezoom_dockwidget_toggled(self):
         if self._dockable_livezoom.isVisible():
@@ -1237,7 +1240,8 @@ class SkyModelPlotter(QWidget):
                 self._dockable_livezoom.setFloating(False)
             else:
                 self._dockable_livezoom.setFloating(True)
-                self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_livezoom.width())
+                if self._mainwin.windowState() != Qt.WindowMaximized:
+                    self._mainwin.setMaximumWidth(self._mainwin.width() + self._dockable_livezoom.width())
 
     def setupShowMessages(self, _signal):
         self.plotShowMessage = _signal


### PR DESCRIPTION
Fixes issue ska-sa#121.

When running Tigger maximised in a VM there is a rendering error when closing dockable windows. This error is only seem within a VM and when Tigger is maximised; if Tigger is running in a windowed state in a VM, no issue is seen.

This PR fixes the unwanted behaviour when running in a VM. In addition, this PR fixes an issue when opening and closing the control dialog repeatedly when Tigger is in a windowed state - window resizing calculation was incorrect.